### PR TITLE
Fix setters

### DIFF
--- a/lib/figgy/hash.rb
+++ b/lib/figgy/hash.rb
@@ -43,7 +43,11 @@ class Figgy
     end
 
     def method_missing(m, *args, &block)
-      self[m]
+      if m =~ /=$/
+        self[m.to_s.chop] = args.shift
+      else
+        self[m]
+      end
     end
   end
 end

--- a/spec/figgy_spec.rb
+++ b/spec/figgy_spec.rb
@@ -101,6 +101,17 @@ describe Figgy do
       second[:still].should == "a dottable hash"
       second["still"].should == "a dottable hash"
     end
+
+    it "supports dottable and indifferent setting" do
+      write_config 'values', "number: 1"
+      config = test_config
+      config.values["number"] = 2
+      config.values.number.should == 2
+      config.values[:number] = 3
+      config.values.number.should == 3
+      config.values.number = 4
+      config.values.number.should == 4
+    end
   end
 
   context "overlays" do


### PR DESCRIPTION
``` ruby
config.abc = 123
```

is translated as 

``` ruby
confog["abc="]
```

This fixes it to translate as

``` ruby
config["abc"] = 123
```

Signed-off-by: Josh Cheek josh.cheek@gmail.com
