### PR TITLE
Add support for Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
+  - 1.8.7
   - 1.9
   - 2.0
   - 2.1

--- a/figgy.gemspec
+++ b/figgy.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", '~> 3.0'
   s.add_development_dependency "simplecov", '~> 0.9'
   s.add_development_dependency "coveralls"
+  s.add_development_dependency "rest-client", '1.6.8' if RUBY_VERSION == "1.8.7"
   s.add_development_dependency "heredoc_unindent"
 end

--- a/figgy.gemspec
+++ b/figgy.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", '~> 3.0'
   s.add_development_dependency "simplecov", '~> 0.9'
   s.add_development_dependency "coveralls"
-  s.add_development_dependency "aruba"
   s.add_development_dependency "heredoc_unindent"
 end

--- a/lib/figgy.rb
+++ b/lib/figgy.rb
@@ -50,6 +50,10 @@ class Figgy
     @store.get(m)
   end
 
+  def respond_to?(m, *)
+    super || respond_to_missing?(m)
+  end if RUBY_VERSION == "1.8.7"
+
   def respond_to_missing?(m, *)
     @store.get(m) != nil
   rescue Figgy::FileNotFound

--- a/lib/figgy/hash.rb
+++ b/lib/figgy/hash.rb
@@ -36,6 +36,10 @@ class Figgy
       self
     end
 
+    def respond_to?(m, *)
+      super || key?(convert_key(m))
+    end if RUBY_VERSION == "1.8.7"
+
     def respond_to_missing?(m, *)
       key?(convert_key(m)) || super
     end

--- a/spec/figgy_spec.rb
+++ b/spec/figgy_spec.rb
@@ -188,6 +188,11 @@ describe Figgy do
       write_config 'reason_to_do_this', nil.to_yaml
       expect(test_config.reason_to_do_this).to eq(nil)
     end
+
+    it "prioritizes hash methods over keys in the YAML file" do
+      write_config 'bad', { 'default' => 'something'}.to_yaml
+      expect(test_config.bad.default).to eq(nil)
+    end
   end
 
   context "multiple roots" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,10 +10,13 @@ SimpleCov.start
 
 require 'rspec'
 require 'figgy'
-require 'aruba/api'
 require 'heredoc_unindent'
 
 module Figgy::SpecHelpers
+  def current_dir
+    File.join(Dir.getwd, 'tmp')
+  end
+
   def test_config
     Figgy.build do |config|
       config.root = current_dir
@@ -23,12 +26,17 @@ module Figgy::SpecHelpers
 
   def write_config(filename, contents)
     filename = "#{filename}.yml" unless filename =~ /\./
-    write_file(filename, contents.unindent)
+    full_filename = File.join(current_dir, filename)
+
+    FileUtils.mkdir_p(File.dirname(full_filename))
+
+    file = File.new(full_filename, "w+")
+    file.write(contents)
+    file.close
   end
 end
 
 RSpec.configure do |c|
-  c.include Aruba::Api
   c.include Figgy::SpecHelpers
 
   c.after { FileUtils.rm_rf(current_dir) }


### PR DESCRIPTION
This pretty much already supports Ruby 1.8.

Only a few things need changing:
* 1.8-only equivalent of `respond_to_missing?`
* Drop Aruba (since it depends on Cucumber, which no longer support Ruby 1.8)
* Add 1.8-only version constraint on restclient